### PR TITLE
Fixed a bug related to join

### DIFF
--- a/tablite/core.py
+++ b/tablite/core.py
@@ -1466,7 +1466,7 @@ class Table(object):
         if kind not in kinds:
             raise ValueError(f"join type unknown: {kind}")
         f = kinds.get(kind,None)
-        return f(self,other,left_keys,right_keys,left_columns,right_columns)
+        return f(other,left_keys,right_keys,left_columns,right_columns)
     
     def _sp_join(self, other, LEFT,RIGHT, left_columns, right_columns):
         """

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 10, 3
+major, minor, patch = 2022, 10, 4
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)


### PR DESCRIPTION
Fixed a bug where the generic  `table.join(...)` would always throw because it already used object methods bound to `self`, causing the call to 

`f(**self**, other,left_keys,right_keys,left_columns,right_columns)` actually become a

`f(**self, self**, other,left_keys,right_keys,left_columns,right_columns)` call.