### PR TITLE
Column statistics fix

### DIFF
--- a/tablite/core.py
+++ b/tablite/core.py
@@ -2160,7 +2160,7 @@ class Column(object):
         - sum (int/float, length of str, date)
         - histogram
         """
-        return summary_statistics(self.histogram())
+        return summary_statistics(*self.histogram())
 
     def __add__(self, other):
         c = self.copy()

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 10, 4
+major, minor, patch = 2022, 10, 5
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)


### PR DESCRIPTION
Without unpacking `self.histogram()`, `column.statistics(self.histogram())` breaks with `TypeError: summary_statistics() missing 1 required positional argument: 'counts'`.

Added unpack symbol to fix this.