### PR TITLE
fix .statistics() and .show() exceptions on empty tables with columns

### DIFF
--- a/tablite/memory_manager.py
+++ b/tablite/memory_manager.py
@@ -258,6 +258,9 @@ class MemoryManager(object):
                     match = page[search_slice]  # page.__getitem__ handles type conversion for Mixed and Str types.
                     arrays.append(match)
             
+            if len(arrays) == 0:
+                return []
+
             dtype, _ = Page.layout(pages)
             return np.concatenate(arrays, dtype=dtype)
     

--- a/tablite/utils.py
+++ b/tablite/utils.py
@@ -99,6 +99,9 @@ def summary_statistics(values,counts):
         if total > most_frequent:
             most_frequent_dtype = dtype
             most_frequent = total
+
+    if most_frequent == 0:
+        return {}
     
     most_frequent_dtype = max(dtypes, key=dtypes.get)
     mask = [type(v)==most_frequent_dtype for v in values]

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 10, 6
+major, minor, patch = 2022, 10, 7
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)


### PR DESCRIPTION
Fixed some problems, where empty tables that have columns would throw an exception when `.statistics()` or `.show()` is called.

`.statistics()` now returns an empty dictionary (although maybe `None` is more appropriate?) as per discussion previously. 

`.show()` doesn't print `Empty table` as it would print with column-less empty table, but instead prints headers of the table with zero rows.