### PR TITLE
More shunts for tqdm/pbar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyperclip==1.8.2
 pyexcel-xlsx==0.6.0
 pyexcel-xls==0.7.0
 pyuca>=1.2
-mplite==1.1.0
+mplite==1.2.0

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 10, 8
+major, minor, patch = 2022, 11, 0
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 0
+major, minor, patch = 2022, 10, 10
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)


### PR DESCRIPTION
Previous tqdm shunt did not shunt all of the tqdm instances, this replaces all tqdm instances with shunted ones and also adds tqdm progress tracking to some other places. Additionally, in some cases for example groupby and sort, pivot that depends on groupby can now share a progress bar instead of creating a new progress bar for each of the actions.