### PR TITLE
Pivot transpose and mode changes

### DIFF
--- a/tablite/core.py
+++ b/tablite/core.py
@@ -3196,7 +3196,30 @@ class Table(object):
         else:
             raise ValueError(f"method {method} not recognised amonst known methods: {list(methods)})")
 
-    def transpose(self, columns, keep=None, column_name="transpose", value_name="value", tqdm=_tqdm):
+    @property
+    def T(self):
+        return self.transpose()
+
+    def transpose(self, tqdm=_tqdm):
+        rows = [[] for _ in range(len(self) + 1)]
+        rows[0] = self.columns[1:]
+
+        for x in tqdm(range(0, len(self)), desc="table transpose"):
+            for y in rows[0]:
+                value = self[y][x]
+                rows[x + 1].append(value)
+
+        unique_names = []
+        table = Table()
+
+        for column_name, values in zip((unique_name(str(c), unique_names) for c in ([self.columns[0]] + list(self[self.columns[0]]))), rows):
+            unique_names.append(column_name)
+
+            table[column_name] = values
+
+        return table
+
+    def pivot_transpose(self, columns, keep=None, column_name="transpose", value_name="value", tqdm=_tqdm):
         """Transpose a selection of columns to rows.
 
         Args:

--- a/tablite/core.py
+++ b/tablite/core.py
@@ -3201,6 +3201,9 @@ class Table(object):
         return self.transpose()
 
     def transpose(self, tqdm=_tqdm):
+        if len(self.columns) == 0:
+            return Table()
+
         rows = [[] for _ in range(len(self) + 1)]
         rows[0] = self.columns[1:]
 

--- a/tablite/utils.py
+++ b/tablite/utils.py
@@ -321,8 +321,15 @@ def _date_statistics_summary(v, c):
 def _string_statistics_summary(v, c):
     vx = [len(x) for x in v]
     d = _numeric_statistics_summary(vx, c)
+
+    vc_sorted = sorted(zip(v, c), key=lambda t: t[1], reverse=True)
+    mode, _ = vc_sorted[0]
+
     for k in d.keys():
         d[k] = f"{d[k]} characters"
+
+    d["mode"] = mode
+    
     return d
 
 

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 3
+major, minor, patch = 2022, 11, 4
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -36,3 +36,48 @@ def test02():
         [10, 20, "d", 40],
         [10, 20, "e", 50],
     ]
+
+def test_03():
+    t = Table()
+    t["a"] = [1, 10]
+    t["b"] = [2, 20]
+    t["c"] = [3, 30]
+    t["d"] = [4, 40]
+    t["e"] = [5, 50]
+
+    new = t.transpose()
+
+    assert new.columns == ["a", "1", "10"]
+    assert [r for r in new.rows] == [
+        ["b", 2, 20],
+        ["c", 3, 30],
+        ["d", 4, 40],
+        ["e", 5, 50]
+    ]
+
+def test_04():
+    t = Table()
+
+    new = t.transpose()
+
+    assert len(new.columns) == 0
+    assert len(new) == 0
+
+
+def test_05():
+    t = Table()
+    t["a"] = []
+    t["b"] = []
+    t["c"] = []
+    t["d"] = []
+    t["e"] = []
+
+    new = t.transpose()
+
+    assert new.columns == ["a"]
+    assert [r for r in new.rows] == [
+        ["b"],
+        ["c"],
+        ["d"],
+        ["e"]
+    ]

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -9,7 +9,7 @@ def test01():
     t["d"] = [4]
     t["e"] = [5]
 
-    new = t.transpose(columns=["c", "d", "e"], keep=["a", "b"])
+    new = t.pivot_transpose(columns=["c", "d", "e"], keep=["a", "b"])
 
     assert [r for r in new.rows] == [
         [1, 2, "c", 3],
@@ -26,7 +26,7 @@ def test02():
     t["d"] = [4, 40]
     t["e"] = [5, 50]
 
-    new = t.transpose(columns=["c", "d", "e"], keep=["a", "b"])
+    new = t.pivot_transpose(columns=["c", "d", "e"], keep=["a", "b"])
 
     assert [r for r in new.rows] == [
         [1, 2, "c", 3],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,7 +171,7 @@ def test_summary_statistics_even_strings():
     assert d["mean"] == "2.857142857142857 characters"
     assert d["median"] == "3 characters"
     assert d["stdev"] == "1.0994504121565505 characters"
-    assert d["mode"] == "4 characters"
+    assert d["mode"] == "dddd"
     assert d["distinct"] == len(V)
     assert d["iqr"] == "2 characters"
     assert d["sum"] == "40 characters"


### PR DESCRIPTION
Renames `transpose()` to `pivot_transpose()` implements, `transpose()` and `T` for table transposition.
Fixes mode value calculation in string types.

Couldn't get the datetime test to work even in the original commits, suspect it has something to do with locales.