### PR TITLE
Added `TABLITE_TMPDIR` env var for tablite db

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+| 2022.11.7 | Added `TABLITE_TMPDIR` environment variable for setting tablite work directory. |
+| 2022.11.6 | Date inference fix |
+| 2022.11.5 | Fixed negative slicing issues |
+| 2022.11.4 | Transpose API changes: <br> `table.transpose(...)` was renamed to `table.pivot_transpose(...)` <br> new `table.transpose()` and `table.T` were added, it's functionality acts similarly to `numpy.T`, the column headers are used the first row in the table when transposing. |
 | 2022.11.3 | Bugfix for non-ascii encoded strings during `t.add_rows(...)` |
 | 2022.11.2 | As `utf-8` is ascii compatible, the file reader utils selects `utf-8` instead of `ascii` as a default. |
 | 2022.11.1 | bugfix in `datatypes.infer()` where 1 was inferred as int, not float. |

--- a/tablite/config.py
+++ b/tablite/config.py
@@ -1,9 +1,11 @@
+import os
 import pathlib
 import tempfile
 
+__tmpdir__ = os.environ.get("TABLITE_TMPDIR", tempfile.gettempdir())
 
 # The default location for the storage
-H5_STORAGE = pathlib.Path(tempfile.gettempdir()) / "tablite.hdf5"
+H5_STORAGE = pathlib.Path(__tmpdir__) / "tablite.hdf5"
 # to overwrite first import the config class:
 # >>> from tablite.config import Config
 # >>> Config.H5_STORAGE = /this/new/location
@@ -19,7 +21,7 @@ SINGLE_PROCESSING_LIMIT = 1_000_000
 # when the number of fields (rows x columns)
 # exceed this value, multiprocessing is used.
 
-TEMPDIR = pathlib.Path(tempfile.gettempdir()) / "tablite-tmp"
+TEMPDIR = pathlib.Path(__tmpdir__) / "tablite-tmp"
 if not TEMPDIR.exists():
     TEMPDIR.mkdir()
 # tempdir for file_reader and other temporary files.

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 6
+major, minor, patch = 2022, 11, 7
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
The current implementation doesn't actually allow to change the tablite db location because memory is a singleton that's initialized the moment anything related `tablite` is imported.

Changing this behaviour would rely on changing all `mem.`  usuages to something like `mem().` where the first call would create the singleton object.

In addition to that, some places would require the change of how `H5_STORAGE` is accessed. e.g. https://github.com/root-11/tablite/blob/master/tablite/memory_manager.py#L12 would have to become `import tablite.config as config` and https://github.com/root-11/tablite/blob/master/tablite/memory_manager.py#L60 would have to become `with h5py.File(config.H5_STORAGE, READWRITE) as h5:` otherwise the `H5_STORAGE` would get locked in to the value first time `tablite` was imported with.

As a middle ground `TABLITE_TMPDIR` env var was added to relocate the tablite db to desired directory before startup. Additional benefit to this is that you can change the directory per virtual environment as opposed to per each application.