### PR TITLE
* fix a nasty bug on single core systems

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+| 2022.11.8 | Fix a bug with task size calculation on single core systems. |
 | 2022.11.7 | Added `TABLITE_TMPDIR` environment variable for setting tablite work directory. <br> Characters that fail to be read text reader due to improper encoding will be skipped. <br> Fixed an issue where single column text files with no column delimiters would be imported as empty tables. |
 | 2022.11.6 | Date inference fix |
 | 2022.11.5 | Fixed negative slicing issues |

--- a/tablite/core.py
+++ b/tablite/core.py
@@ -259,7 +259,7 @@ def _text_reader_task_size(
 
     """
     bytes_per_line = math.ceil(filesize / newlines)
-    total_workload = working_overhead * filesize
+    total_workload = max(working_overhead, 1) * filesize
 
     reserved_memory = int(free_virtual_memory * memory_usage_ceiling)
 
@@ -287,7 +287,7 @@ def _text_reader_task_size(
 
         if not multicore:  # it's a large task and there is no memory for another python subprocess.
             # Use current process and divide the total workload to fit into free memory.
-            lines_per_task = newlines // max(1, total_workload // reserved_memory)
+            lines_per_task = newlines // max(1, math.ceil(total_workload / reserved_memory))
             cpu_count = 0
 
     return lines_per_task, cpu_count

--- a/tablite/core.py
+++ b/tablite/core.py
@@ -287,7 +287,7 @@ def _text_reader_task_size(
 
         if not multicore:  # it's a large task and there is no memory for another python subprocess.
             # Use current process and divide the total workload to fit into free memory.
-            lines_per_task = max(1, total_workload // reserved_memory)
+            lines_per_task = newlines // max(1, total_workload // reserved_memory)
             cpu_count = 0
 
     return lines_per_task, cpu_count

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 7
+major, minor, patch = 2022, 11, 8
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
There was an arithmetic error that would trigger only on single core machines where the file would split up in too many tasks (1 task per 1 line if file fits fully in memory) causing the file reader to not only slow down significantly but also create way too many pages bloating the disk database.