### PR TITLE
Allow safe failing on invalid characters when reading header

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+| 2022.11.9 | `get_headers` can fail safe on unrecognized characters. |
 | 2022.11.8 | Fix a bug with task size calculation on single core systems. |
 | 2022.11.7 | Added `TABLITE_TMPDIR` environment variable for setting tablite work directory. <br> Characters that fail to be read text reader due to improper encoding will be skipped. <br> Fixed an issue where single column text files with no column delimiters would be imported as empty tables. |
 | 2022.11.6 | Date inference fix |

--- a/tablite/file_reader_utils.py
+++ b/tablite/file_reader_utils.py
@@ -230,7 +230,7 @@ def get_headers(path, linecount=10, delimiter=None):
         with path.open("rb") as fi:
             rawdata = fi.read(ENCODING_GUESS_BYTES)
             encoding = chardet.detect(rawdata)["encoding"]
-        with path.open("r", encoding=encoding) as fi:
+        with path.open("r", encoding=encoding, errors="ignore") as fi:
             lines = []
             for n, line in enumerate(fi):
                 line = line.rstrip("\n")
@@ -260,7 +260,7 @@ def get_encoding(path):
 
 
 def get_delimiter(path, encoding):
-    with path.open("r", encoding=encoding) as fi:
+    with path.open("r", encoding=encoding, errors="ignore") as fi:
         lines = []
         for n, line in enumerate(fi):
             line = line.rstrip("\n")

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 8
+major, minor, patch = 2022, 11, 9
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Some character encodings are just not feasible to distinguish without entire file analysis, allow safe failing and skip those characters.