### PR TITLE
fix empty page value error when creating an empty table with memory manager

### DIFF
--- a/tablite/memory_manager.py
+++ b/tablite/memory_manager.py
@@ -169,8 +169,6 @@ class MemoryManager(object):
             assert isinstance(all_pages, Pages)
 
             for page in pages_after:
-                if len(page) == 0:
-                    raise ValueError("page length == 0")
                 self.ref_counts[page.group] += 1
             for page in pages_before:
                 self.ref_counts[page.group] -= 1

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 12
+major, minor, patch = 2022, 11, 13
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,4 +1,5 @@
-from tablite.memory_manager import timeout
+from tablite.memory_manager import timeout, MemoryManager
+from tablite import Table
 import time
 
 
@@ -17,3 +18,24 @@ def test_timeout_result():
     for i in [1, 3]:
         x = sleepy(i)  # tests that the timeout decorator works on sleepy
         assert x == i
+
+
+def test_empty_table_creation():
+    """
+        Was failing when creating a table with some empty pages, however equivalent form presented below was passing.
+        
+        mem = MemoryManager()
+        cols = { "A": [], "B": [], "C": [], } 
+        new_table = Table.from_dict(cols) 
+        t = Table.load(mem.path, new_table.key)
+    """
+    mem = MemoryManager()
+    cols = { 
+        "A": mem.mp_write_column(values=[]), 
+        "B": mem.mp_write_column(values=[]), 
+        "C": mem.mp_write_column(values=[]), 
+    } 
+    new_table_key = mem.new_id("/table") 
+    mem.mp_write_table(new_table_key, columns=cols) 
+    t = Table.load(mem.path, new_table_key) 
+    assert len(t) == 0


### PR DESCRIPTION
Creating empty table with memory manager is failing, because some pages are empty. However, if we create empty table with other methods under Table class - no issues are raised. In the end, both ways should work the same. 