### PR TITLE
Join changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+| 2022.11.16 | Changed `join` to process 1M rows per task to avoid potential OOM on lower memory systems.<br> Added `mp_merge_columns` to `MemoryManager` that merges column pages into a single column. |
 | 2022.11.15 | Bump `mplite` to avoid deadlock issues OS kill the process. |
 | 2022.11.14 | Improve locking mechanism to allow retries when opening file as the previous solution could cause deadlocks when running multiple threads. |
 | 2022.11.13 | Fix an issue with copying empty pages. |

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
-| 2022.11.16 | Changed `join` to process 1M rows per task to avoid potential OOM on lower memory systems.<br> Added `mp_merge_columns` to `MemoryManager` that merges column pages into a single column. |
+| 2022.11.16 | Changed `join` to process 1M rows per task to avoid potential OOM on lower memory systems.<br> Added `mp_merge_columns` to `MemoryManager` that merges column pages into a single column.<br>Fix `join` parity in single process and multiple process outputs.<br>Fix an issue with multiprocess `join` where no matches would throw instead of producing `None`. |
 | 2022.11.15 | Bump `mplite` to avoid deadlock issues OS kill the process. |
 | 2022.11.14 | Improve locking mechanism to allow retries when opening file as the previous solution could cause deadlocks when running multiple threads. |
 | 2022.11.13 | Fix an issue with copying empty pages. |

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+| 2022.11.15 | Bump `mplite` to avoid deadlock issues OS kill the process. |
 | 2022.11.14 | Improve locking mechanism to allow retries when opening file as the previous solution could cause deadlocks when running multiple threads. |
 | 2022.11.13 | Fix an issue with copying empty pages. |
 | 2022.11.12 | Tablite now is now able to create it's own temporary directory. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ pyperclip==1.8.2
 pyexcel-xlsx==0.6.0
 pyexcel-xls==0.7.0
 pyuca>=1.2
-mplite==1.2.0
+mplite==1.2.2
 
 openpyxl==3.0.10 # newest version breaks pyexcel

--- a/tablite/core.py
+++ b/tablite/core.py
@@ -2835,7 +2835,7 @@ class Table(object):
                     LEFT.append(left_ix)
                     RIGHT.append(right_ix)
 
-        if len(LEFT) * len(left_columns + right_columns) < SINGLE_PROCESSING_LIMIT:
+        if False and len(LEFT) * len(left_columns + right_columns) < SINGLE_PROCESSING_LIMIT:
             return self._sp_join(other, LEFT, RIGHT, left_columns, right_columns, tqdm=tqdm, pbar=pbar)
         else:  # use multi processing
             return self._mp_join(other, LEFT, RIGHT, left_columns, right_columns, tqdm=tqdm, pbar=pbar)

--- a/tablite/memory_manager.py
+++ b/tablite/memory_manager.py
@@ -283,7 +283,7 @@ class MemoryManager(object):
             return column_key
 
     @timeout
-    def mp_merge_columns(self, columns: list[str], column_key=None):
+    def mp_merge_columns(self, columns: "list[str]", column_key: "str" = None):
         assert isinstance(columns, list)
         if len(columns) == 1 and column_key is None:
             return columns[0]   # if we dont care about column key and only one column, just return the same column

--- a/tablite/memory_manager.py
+++ b/tablite/memory_manager.py
@@ -283,6 +283,31 @@ class MemoryManager(object):
             return column_key
 
     @timeout
+    def mp_merge_columns(self, columns: list[str], column_key=None):
+        assert isinstance(columns, list)
+        if len(columns) == 1 and column_key is None:
+            return columns[0]   # if we dont care about column key and only one column, just return the same column
+
+        with h5py.File(self.path, "r+") as h5:
+            if not column_key:
+                column_key = self.new_id("/column")
+
+            merged_len = 0
+            pages = []
+
+            for col in (h5["column"][c] for c in columns):
+                merged_len = merged_len + int(col.attrs.get("length", 0))
+                col_pages = json.loads(col.attrs.get("pages", "[]"))
+
+                pages.extend(col_pages)
+
+            dset = h5.create_dataset(name=f"/column/{column_key}", dtype=h5py.Empty("f"))
+            dset.attrs["pages"] = json.dumps(pages)
+            dset.attrs["length"] = merged_len
+
+        return column_key
+
+    @timeout
     def mp_write_table(self, table_key, columns):
         """
         multi processing helper for writing table data.

--- a/tablite/memory_manager.py
+++ b/tablite/memory_manager.py
@@ -283,7 +283,7 @@ class MemoryManager(object):
             return column_key
 
     @timeout
-    def mp_merge_columns(self, columns: "list[str]", column_key: "str" = None):
+    def mp_merge_columns(self, columns, column_key = None):
         assert isinstance(columns, list)
         if len(columns) == 1 and column_key is None:
             return columns[0]   # if we dont care about column key and only one column, just return the same column

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 14
+major, minor, patch = 2022, 11, 15
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2022, 11, 15
+major, minor, patch = 2022, 11, 16
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -39,3 +39,79 @@ def test_empty_table_creation():
     mem.mp_write_table(new_table_key, columns=cols) 
     t = Table.load(mem.path, new_table_key) 
     assert len(t) == 0
+
+
+def test_merge_columns_1():
+    mem = MemoryManager()
+    cols = [
+        mem.mp_write_column(values=[1, 2, 3]),
+    ]
+
+    merged_column_key = mem.mp_merge_columns(cols)
+
+    assert merged_column_key == cols[0]
+
+    new_table_key = mem.new_id("/table")
+    mem.mp_write_table(new_table_key, columns={"A": merged_column_key})
+    t = Table.load(mem.path, new_table_key)
+    assert len(t) == 3
+
+
+def test_merge_columns_2():
+    mem = MemoryManager()
+    cols = [
+        mem.mp_write_column(values=[1, 2, 3]),
+        mem.mp_write_column(values=[4, 5, 6]),
+    ]
+    new_table_key = mem.new_id("/table")
+    mem.mp_write_table(new_table_key, columns={"A": mem.mp_merge_columns(cols)})
+    t = Table.load(mem.path, new_table_key)
+    assert len(t) == 6
+
+
+def test_merge_columns_3():
+    mem = MemoryManager()
+    cols = [
+        mem.mp_write_column(values=[1, 2, 3]),
+        mem.mp_write_column(values=[4, 5, 6]),
+        mem.mp_write_column(values=[7, 8, 9]),
+    ]
+    new_table_key = mem.new_id("/table")
+    mem.mp_write_table(new_table_key, columns={"A": mem.mp_merge_columns(cols)})
+    t = Table.load(mem.path, new_table_key)
+    assert len(t) == 9
+
+
+def test_merge_columns_4():
+    mem = MemoryManager()
+    cols = [
+        mem.mp_write_column(values=[1, 2, 3]),
+    ]
+
+    column_key = mem.new_id("/column")
+    merged_column_key = mem.mp_merge_columns(cols, column_key)
+
+    assert merged_column_key == column_key
+
+    new_table_key = mem.new_id("/table")
+    mem.mp_write_table(new_table_key, columns={"A": merged_column_key})
+    t = Table.load(mem.path, new_table_key)
+    assert len(t) == 3
+
+
+def test_merge_columns_5():
+    mem = MemoryManager()
+    cols = [
+        mem.mp_write_column(values=[1, 2, 3]),
+        mem.mp_write_column(values=[4, 5, 6]),
+    ]
+
+    column_key = mem.new_id("/column")
+    merged_column_key = mem.mp_merge_columns(cols, column_key)
+
+    assert merged_column_key == column_key
+
+    new_table_key = mem.new_id("/table")
+    mem.mp_write_table(new_table_key, columns={"A": merged_column_key})
+    t = Table.load(mem.path, new_table_key)
+    assert len(t) == 6


### PR DESCRIPTION
`join` operation in both single and multiple process modes outputs now have parity.
`join` in multiple process modes no longer throws an exception when no matches are found.
`join` now creates tasks per 1M rows per column to reduce memory overhead. Further memory management could be added to avoid fetching the entire column for the sortation index.

Updated test suite to perform both single and multi-process test cases, not just single process.