### PR TITLE
* subclassing

### DIFF
--- a/tablite/groupbys.py
+++ b/tablite/groupbys.py
@@ -120,7 +120,7 @@ def groupby(T, keys, functions, tqdm=_tqdm, pbar=None):  # TODO: This is single 
     # only keys will produce unique values for each key group.
     if keys and not functions:
         cols = list(zip(*T.index(*keys)))
-        result = Table()
+        result = T.__class__()
 
         pbar = tqdm(total=len(keys), desc="groupby") if pbar is None else pbar
 


### PR DESCRIPTION
Fix an issue with subclassing inconsistency. `groupby` would create a `table.base.Table` instead of `table.core.Table` or subclass of input table.