### PR TITLE
* bump mplite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+|2023.6.2| Updated `mplite` dependency, changed to soft version requirement to prevent pipeline freezes due to small bugfixes in `mplite`. |
 |2023.6.1| Major change of the backend processes. Speed up of ~6x. For more see the [release notes](https://github.com/root-11/tablite/releases/tag/2023.6.1) |
 | 2022.11.19 | Fixed some memory leaks. |
 | 2022.11.18 | `copy`, `filter`, `sort`, `any`, `all` methods now properly respects the table subclass.<br>Filter for tables with under `SINGLE_PROCESSING_LIMIT` rows will run on same process to reduce overhead.<br>Errors within child processes now properly propagate to parent.<br>`Table.reset_storage(include_imports=True)` now allows the user to reset the storage but exclude any imported files by setting `include_imports=False` during `Table.reset(...)`.<br>Bug: A column with `1,None,2` would be written to csv & tsv as `"1,None,2"`. Now it is written `"1,,2"` where None means absent.<br>Fix mp `join` producing mismatched columns lengths when different table lengths are used as an input or when join product is longer than the input table. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyexcel-ods==0.6.0
 pyexcel-xlsx==0.6.0
 pyexcel-xls==0.7.0
 pyuca>=1.2
-mplite==1.2.2
+mplite>=1.2.3
 PyYAML==6.0
 openpyxl==3.0.10 # newest version breaks pyexcel
 h5py>=3.6.0

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 6, 1
+major, minor, patch = 2023, 6, 2
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Hard version lock prevents other packages from upgrading `mplite` to one with fixed concurrency bug.