### PR TITLE
Fix get_headers linecount issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+|2023.6.4| Fix a logic bug in `get_headers` that caused one extra line to be returned than requested. |
 |2023.6.3| Updated the way reference counting works. Tablite now tracks references to used pages and cleans them up based on number of references to those pages in the current process. This change allows to handle deep table clones when sending tables via processes (pickling/unpickling), whereas previous implementation would corrupt all tables using same pages due to reference counting asserting that all tables are shallow copies to the same object.
 |2023.6.2| Updated `mplite` dependency, changed to soft version requirement to prevent pipeline freezes due to small bugfixes in `mplite`. |
 |2023.6.1| Major change of the backend processes. Speed up of ~6x. For more see the [release notes](https://github.com/root-11/tablite/releases/tag/2023.6.1) |

--- a/tablite/file_reader_utils.py
+++ b/tablite/file_reader_utils.py
@@ -265,7 +265,7 @@ def get_headers(path, delimiter=None, header_row_index=0, text_qualifier=None, l
                     continue
                 line = line.rstrip("\n")
                 lines.append(line)
-                if n > linecount:
+                if n >= linecount:
                     break  # break on first
 
             if delimiter is None:

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 6, 3
+major, minor, patch = 2023, 6, 4
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Fix a logic bug in `get_headers` that caused one extra line to be returned than requested.