### PR TITLE
Fix xls get_headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                              |
 |:-----------|-----------------------------------------------------|
+|2023.6.5| Fix issues with `get_headers` falling back to text reading when reading 0 lines of excel, fix issue where reading excel file would ignore file count, excel file reader now has parity for linecount selection. |
 |2023.6.4| Fix a logic bug in `get_headers` that caused one extra line to be returned than requested. |
 |2023.6.3| Updated the way reference counting works. Tablite now tracks references to used pages and cleans them up based on number of references to those pages in the current process. This change allows to handle deep table clones when sending tables via processes (pickling/unpickling), whereas previous implementation would corrupt all tables using same pages due to reference counting asserting that all tables are shallow copies to the same object.
 |2023.6.2| Updated `mplite` dependency, changed to soft version requirement to prevent pipeline freezes due to small bugfixes in `mplite`. |

--- a/tablite/file_reader_utils.py
+++ b/tablite/file_reader_utils.py
@@ -230,14 +230,14 @@ def get_headers(path, delimiter=None, header_row_index=0, text_qualifier=None, l
                 all_sheets = book.sheetnames
 
                 for sheet_name, sheet in ((name, book[name]) for name in all_sheets):
-                    max_rows = min(sheet.max_row, max(1, linecount))
+                    max_rows = min(sheet.max_row, linecount + 1)
                     container = [None] * max_rows
                     padding_ends = 0
                     max_column = sheet.max_column
 
                     for i, row_data in enumerate(sheet.iter_rows(0, header_row_index + max_rows, values_only=True), start=-header_row_index):
                         if i < 0:
-                            # NOTE: for some reason `iter_rows` specifying a start row starts reading cells as binary, instead skip the lines that are before our first read line
+                            # NOTE: for some reason `iter_rows` specifying a start row starts reading cells as binary, instead skip the rows that are before our first read row
                             continue
                         
                         # NOTE: text readers do not cast types and give back strings, neither should xlsx reader, can't find documentation if it's possible to ignore this via `iter_rows` instead of casting back to string

--- a/tablite/file_reader_utils.py
+++ b/tablite/file_reader_utils.py
@@ -2,6 +2,7 @@ import re
 import chardet
 import openpyxl
 from pathlib import Path
+from tablite.datatypes import DataTypes
 
 ENCODING_GUESS_BYTES = 10000
 
@@ -229,13 +230,18 @@ def get_headers(path, delimiter=None, header_row_index=0, text_qualifier=None, l
                 all_sheets = book.sheetnames
 
                 for sheet_name, sheet in ((name, book[name]) for name in all_sheets):
-                    max_rows = min(sheet.max_row, linecount)
+                    max_rows = min(sheet.max_row, max(1, linecount))
                     container = [None] * max_rows
                     padding_ends = 0
                     max_column = sheet.max_column
 
-                    for i, row_data in enumerate(sheet.iter_rows(0, max_rows, values_only=True)):
-                        container[i] = list(row_data)
+                    for i, row_data in enumerate(sheet.iter_rows(0, header_row_index + max_rows, values_only=True), start=-header_row_index):
+                        if i < 0:
+                            # NOTE: for some reason `iter_rows` specifying a start row starts reading cells as binary, instead skip the lines that are before our first read line
+                            continue
+                        
+                        # NOTE: text readers do not cast types and give back strings, neither should xlsx reader, can't find documentation if it's possible to ignore this via `iter_rows` instead of casting back to string
+                        container[i] = [DataTypes.to_json(v) for v in row_data]
 
                         for j, cell in enumerate(reversed(row_data)):
                             if cell is None:

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 6, 4
+major, minor, patch = 2023, 6, 5
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Fix issues with `get_headers` falling back to text reading when reading 0 lines of excel, fix issue where reading excel file would ignore file count, excel file reader now has parity for linecount selection.