### PR TITLE
Removed the nim runtime requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/
 # personal notes
 *scratch*.py
 _nimlite/nimlite
+_nimlite/*.so
+_nimlite/*.pyd

--- a/tablite/config.py
+++ b/tablite/config.py
@@ -33,7 +33,8 @@ class Config(object):
     BACKEND_NIM = "NIM"
     BACKEND_PYTHON = "PYTHON"
     BACKEND = BACKEND_PYTHON if platform.system() == "Windows" else BACKEND_NIM
-    
+    USE_NIMPORTER = os.environ.get("USE_NIMPORTER", "false").lower() in ["1", "t", "true", "y", "yes"]
+
     NIM_SUPPORTED_CONV_TYPES = ["Windows-1252", "ISO-8859-1"]
 
     workdir = pathlib.Path(os.environ.get("TABLITE_TMPDIR", f"{tempfile.gettempdir()}/tablite-tmp"))

--- a/tablite/nimlite.py
+++ b/tablite/nimlite.py
@@ -18,7 +18,10 @@ CLI_BACKEND_PATH = Path(__file__).parent.parent / f"_nimlite/nimlite{'.exe' if I
 
 if not USE_CLI_BACKEND:
     paths = sys.argv[:]
-    import nimporter
+    if Config.USE_NIMPORTER:
+        import nimporter
+
+        nimporter.Nimporter.IGNORE_CACHE = True
     import _nimlite.nimlite as nl
 
     sys.argv.clear()

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 8, "dev0"
+major, minor, patch = 2023, 8, "dev1"
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Removed requirement to have `nim/nimble` installed for consuming the library, only needed for development now.