### PR TITLE
* resolve an issue with `np.take` and `<U0` dtype

### DIFF
--- a/tablite/_nimlite/paging.nim
+++ b/tablite/_nimlite/paging.nim
@@ -18,9 +18,11 @@ proc collectPageInfo*(
         import_fields: var seq[uint]
     ): (uint, seq[uint], seq[Rank]) =
     var ranks: seq[Rank]
-    var longest_str = newSeq[uint](n_pages)
+    var longest_str = collect(newSeqOfCap(n_pages)):
+        for _ in 0..n_pages-1:
+            1u
+    
     var n_rows: uint = 0
-
 
     if guess_dtypes:
         ranks = collect(newSeqOfCap(n_pages)):

--- a/tablite/import_utils.py
+++ b/tablite/import_utils.py
@@ -511,7 +511,7 @@ def text_reader_task(
         page_file_handlers = [open(f, mode="wb") for f in destination]
 
         # identify longest str
-        longest_str = [0 for _ in range(len(destination))]
+        longest_str = [1 for _ in range(len(destination))]
         for row in (next(reader) for _ in range(end - start)):
             for idx, c in ((fields[idx], c) for idx, c in filter(lambda t: t[0] in fields, enumerate(row))):
                 longest_str[idx] = max(longest_str[idx], len(c))

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 8, 3
+major, minor, patch = 2023, 8, 4
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
`np.take` produces a `<U1` from `<U0` array which causes internal np.array misalignment. Clamp the minimum string length to 1 so that unicode pages are always at least the size of `<U1` .