### PR TITLE
Fix nimporter to support newlines in qualified strings

### DIFF
--- a/tablite/_nimlite/encfile.nim
+++ b/tablite/_nimlite/encfile.nim
@@ -152,30 +152,9 @@ proc newFile*(filename: string, encoding: FileEncoding): BaseEncodedFile =
         of ENC_UTF16: return newFileUTF16(filename)
         of ENC_CONV: return newFileConvertable(filename, encoding.conv)
 
-proc findNewlines*(fh: BaseEncodedFile): (seq[uint], uint) =
-    var newline_offsets = newSeq[uint](1)
-    var total_lines: uint = 0
-    var str: string
-
-    newline_offsets[0] = fh.getFilePos()
-
-    while likely(fh.readLine(str)):
-        inc total_lines
-
-        newline_offsets.add(fh.getFilePos())
-
-    return (newline_offsets, total_lines)
-
-proc findNewlines*(path: string, encoding: FileEncoding): (seq[uint], uint) =
-    let fh = newFile(path, encoding)
-    try:
-        return findNewlines(fh)
-    finally:
-        fh.close()
-
 proc str2Enc*(encoding: string): FileEncoding {.inline.} =
     let upper = encoding.toUpper()
-    
+
     case upper:
         of $ENC_UTF8: return FileEncoding(encoding: ENC_UTF8)
         of $ENC_UTF16: return FileEncoding(encoding: ENC_UTF16)

--- a/tablite/_nimlite/nimlite.nim
+++ b/tablite/_nimlite/nimlite.nim
@@ -251,10 +251,12 @@ when isMainModule and appType != "lib":
 
     if opts.import.isNone and opts.task.isNone:
         when defined(DEV_BUILD):
+            # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/split_lines.csv", str2Enc($ENC_UTF8))
+            (path_csv, encoding) = ("/home/ratchet/Documents/dematic/callisto/tests/testing/data/Dealz Poland v1.csv", str2Enc($ENC_UTF8))
             # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/bad_empty.csv", str2Enc($ENC_UTF8))
             # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/book1.csv", str2Enc($ENC_UTF8))
             # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/utf16_test.csv", str2Enc($ENC_UTF16))
-            (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/win1250_test.csv", str2ConvEnc("Windows-1252"))
+            # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/win1250_test.csv", str2ConvEnc("Windows-1252"))
 
             # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/book1.txt", str2Enc($ENC_UTF8))
             # (path_csv, encoding) = ("/home/ratchet/Documents/dematic/tablite/tests/data/gdocs1.csv", str2Enc($ENC_UTF8))
@@ -269,7 +271,7 @@ when isMainModule and appType != "lib":
             # dialect.quoting = Quoting.QUOTE_NONE
             # dialect.delimiter = ';'
 
-            let multiprocess = true
+            let multiprocess = false
             let execute = true
             let start = some[int](0)
             let limit = some[int](-1)
@@ -277,6 +279,7 @@ when isMainModule and appType != "lib":
             let header_row_index = uint 0
 
             guess_dtypes = true
+            # page_size = 2
 
             echo "Running test version with no arguments"
             importFile(pid, taskname, path_csv, encoding, dialect, cols, first_row_has_headers, header_row_index, page_size, guess_dtypes, start, limit, multiprocess, execute, use_json)

--- a/tablite/_nimlite/textreader.nim
+++ b/tablite/_nimlite/textreader.nim
@@ -78,7 +78,7 @@ proc importTextFile*(
 
     let opt_start = (if start.isSome: start.get else: 0)
     let opt_limit = (if limit.isSome: limit.get else: -1)
-    let (newline_offsets, newlines) = findNewlines(path, encoding)
+    let (newline_offsets, newlines) = findNewlines(path, encoding, dia)
     let dirname = pid & "/pages"
 
     if not dirExists(dirname):
@@ -189,4 +189,3 @@ proc importTextFile*(
         return table
     else:
         raise newException(IOError, "end of file")
-

--- a/tablite/config.py
+++ b/tablite/config.py
@@ -35,8 +35,12 @@ class Config(object):
 
     BACKEND_NIM = "NIM"
     BACKEND_PYTHON = "PYTHON"
-    BACKEND = BACKEND_PYTHON if platform.system() == "Windows" else BACKEND_NIM
+    BACKEND = BACKEND_PYTHON if platform.system() == "Windows" else os.environ.get("USE_BACKEND", BACKEND_NIM).upper()
+
+    assert BACKEND in [BACKEND_NIM, BACKEND_PYTHON]
+
     USE_NIMPORTER = os.environ.get("USE_NIMPORTER", "true").lower() in ["1", "t", "true", "y", "yes"]
+    ALLOW_CSV_READER_FALLTHROUGH = os.environ.get("ALLOW_CSV_READER_FALLTHROUGH", "true").lower() in ["1", "t", "true", "y", "yes"]
 
     NIM_SUPPORTED_CONV_TYPES = ["Windows-1252", "ISO-8859-1"]
 

--- a/tablite/import_utils.py
+++ b/tablite/import_utils.py
@@ -842,7 +842,7 @@ def text_reader(*args, **kwargs):
         try:
             return text_reader_nim(*args, **kwargs)
         except Exception as e:
-            if "pytest" in sys.modules:
+            if "pytest" in sys.modules or not Config.ALLOW_CSV_READER_FALLTHROUGH:
                 raise e # ensure that fallback is only used during production
             else:
                 from traceback import format_exc

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 8, 4
+major, minor, patch = 2023, 8, 5
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/tests/data/split_lines.csv
+++ b/tests/data/split_lines.csv
@@ -1,0 +1,6 @@
+a,b,c
+"aaa
+bbb",1,0
+"ccc
+ddd",2,0
+eee,3,0

--- a/tests/test_filereader_formats.py
+++ b/tests/test_filereader_formats.py
@@ -1,3 +1,4 @@
+from tablite.config import Config
 from tablite import Table
 from tablite.file_reader_utils import TextEscape, get_headers, ENCODING_GUESS_BYTES
 from tablite.datatypes import DataTypes
@@ -580,6 +581,28 @@ def test_keep_some_columns_only():
     table = Table.from_file(path, columns=["a", "b"])
     assert set(table.columns) == {"a", "b"}
     assert len(table) == 45
+
+def test_split_lines():
+    if Config.BACKEND == Config.BACKEND_PYTHON:
+        """
+            It is not possible to currently implement this in Windows using existing Python APIs.
+            Using `csv.parse` to find newlines is impossible because calling an iterator blocks `fi.tell()`.
+            Therefore implementing this in Windows would require to implement the entire CSV parser in python itself.
+            This is double work as we have a nim implementation.
+            
+            Therefore a solution is, use NIM in Windows when we find the solution on how to do it.
+            Until then, ignore this test in Windows.
+        """
+        return
+
+    path = Path(__file__).parent / "data" / "split_lines.csv"
+    assert path.exists()
+    table = Table.from_file(path, text_qualifier="\"", columns=["a", "c"])
+    assert set(table.columns) == {"a", "c"}
+    assert len(table) == 3
+    assert table["a"] == ['aaa\\nbbb', 'ccc\\nddd', 'eee']
+    assert table["c"] == [0, 0, 0]
+
 
 
 def test_long_texts():


### PR DESCRIPTION
Fixes the issue where some csvs had newline characters inbetween qualified (quoted) strings causing segfault when trying to load in numpy because the pages got mis-alligned.

Cannot be resolved in pythonic implementation (windows) because using `csv.parser` module locks python out from the file handler to know where the file reader head is.