### PR TITLE
Bump tablite version to 2023.8.7

### DIFF
--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 8, "dev72"
+major, minor, patch = 2023, 8, 7
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
The dev version generated proper pyd's in the wheel.