### PR TITLE
Join changes

### DIFF
--- a/nimlite/pymodules.nim
+++ b/nimlite/pymodules.nim
@@ -60,6 +60,7 @@ type PyModules {.requiresInit.} = object
     mplite*: PyModule[PyMplite]
     nimlite*: PyEmptyModule
     tqdm*: PyModule[PyTqdm]
+    math*: PyEmptyModule
 
 proc newModule[K, T](Class: typedesc[K], module: nimpy.PyObject, classes: T): K {.inline.} = Class(module: module, classes: classes)
 proc newModule[K, T1, T2](Class: typedesc[K], module: nimpy.PyObject, classes: T1, modules: T2): K {.inline.} = Class(module: module, classes: classes, modules: modules)
@@ -86,6 +87,7 @@ proc importPy(): void =
     let iNumpy = nimpy.pyImport("numpy")
     let iTqdm = nimpy.pyImport("tqdm")
     let iNimlite = nimpy.pyImport("tablite.nimlite")
+    let iMath = nimpy.pyImport("math")
 
     let iPyBuiltins = PyBuiltins(
         NoneTypeClass: iBuiltins.None.getattr("__class__"),
@@ -124,6 +126,7 @@ proc importPy(): void =
         mplite: PyModule[PyMplite].newModule(iMplite, iPyMplite),
         nimlite: newEmptyModule(iNimlite),
         tqdm: PyModule[PyTqdm].newModule(iTqdm, iPyTqdm),
+        math: newEmptyModule(iMath),
     )
 
     py = some(pyModules)

--- a/tablite/mp_utils.py
+++ b/tablite/mp_utils.py
@@ -43,6 +43,29 @@ filter_ops = {
 filter_ops_from_text = {"gt": ">", "gteq": ">=", "eq": "==", "lt": "<", "lteq": "<=", "neq": "!=", "in": _in}
 
 
+def is_mp(fields: int) -> bool:
+    """
+
+    Args:
+        fields (int): number of fields
+
+    Returns:
+        bool
+    """
+    if Config.MULTIPROCESSING_MODE == Config.FORCE:
+        return True
+    
+    if Config.MULTIPROCESSING_MODE == Config.FALSE:
+        return False
+    
+    if fields < Config.SINGLE_PROCESSING_LIMIT:
+        return False
+    
+    if max(psutil.cpu_count(logical=False), 1) < 2:
+        return False
+
+    return True
+
 def select_processing_method(fields, sp, mp):
     """
 
@@ -54,18 +77,7 @@ def select_processing_method(fields, sp, mp):
     Returns:
         _type_: _description_
     """
-    if Config.MULTIPROCESSING_MODE == Config.FORCE:
-        m = mp
-    elif Config.MULTIPROCESSING_MODE == Config.FALSE:
-        m = sp
-    elif fields < Config.SINGLE_PROCESSING_LIMIT:
-        m = sp
-    elif max(psutil.cpu_count(logical=False), 1) < 2:
-        m = sp
-    else:
-        m = mp
-    return m
-
+    return mp if is_mp(fields) else sp
 
 def maskify(arr):
     none_mask = [False] * len(arr)  # Setting the default

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 10, 1
+major, minor, patch = 2023, 10, 2
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
A problem arose with multiprocessing branch of the join producing invalid results. The problem is that mapping cannot be multiprocessed/run on fixed memory. `Left` table slice depends on the entire `Right` table indices additionally `Left` table slices depend on indices from all previous slices. Therefore this part was moved to be single processed.

Best we can do is reduce the memory footprint required by index dictionaries by either using hash of value as key instead of value itself or outright moving this to nim to reduce the object footprint.

Additionally, multiprocessing and singleprocessing join branches have been merged into one so that only a single algorithm needs to be maintained.