### PR TITLE
fix imputation inconsistency

### DIFF
--- a/nimlite.nimble
+++ b/nimlite.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Ratchet"
 description   = "Utilities for tablite to work with nim"
 license       = "MIT"

--- a/tablite/imputation.py
+++ b/tablite/imputation.py
@@ -106,7 +106,7 @@ def carry_forward(T, targets, missing, tqdm=_tqdm, pbar=None):
         total = len(targets) * len(T)
         pbar = tqdm(total=total, desc="imputation.carry_forward", disable=Config.TQDM_DISABLE)
 
-    new = type(T)()
+    new = T.copy()
     for name in T.columns:
         if name in targets:
             data = T[name][:]  # create copy
@@ -131,7 +131,7 @@ def stats_method(T, targets, missing, method, tqdm=_tqdm, pbar=None):
         total = len(targets)
         pbar = tqdm(total=total, desc=f"imputation.{method}", disable=Config.TQDM_DISABLE)
 
-    new = type(T)()
+    new = T.copy()
     for name in T.columns:
         if name in targets:
             col = T.columns[name]

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 10, 9
+major, minor, patch = 2023, 10, 10
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Fix inconsistencies with imputation three methods being in-place, meanwhile NN was copy. Most of the tablite functions are copy, so it makes more sense to change the other imputation methods to be copy too instead of changing the NN method to be inplace.