### PR TITLE
Fix potential layout mismatch

### DIFF
--- a/nimlite.nimble
+++ b/nimlite.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Ratchet"
 description   = "Utilities for tablite to work with nim"
 license       = "MIT"

--- a/nimlite/numpy.nim
+++ b/nimlite/numpy.nim
@@ -191,7 +191,7 @@ iterator pgIter*(self: UnicodeNDArray): string =
 template fullPrint(T: typed, name: string, buf: string): string = "NDArray[" & name & "](shape: (" & self.shape.join(", ") & (if self.shape.len > 1: ")" else: ", )") & " buf: [" & buf & "])"
 template simplePrint(T: typed, name: string): string = self.fullPrint(name, self.buf.join(", "))
 
-method `$`(self: BaseNDArray): string {.base.} = implement("BaseNDArray.`$` must be implemented by inheriting class: " & $self.kind)
+method `$`*(self: BaseNDArray): string {.base.} = implement("BaseNDArray.`$` must be implemented by inheriting class: " & $self.kind)
 method `$`*(self: BooleanNDArray): string = self.simplePrint("boolean")
 method `$`*(self: Int8NDArray): string = self.simplePrint("int8")
 method `$`*(self: Int16NDArray): string = self.simplePrint("int16")

--- a/nimlite/pymodules.nim
+++ b/nimlite/pymodules.nim
@@ -75,8 +75,6 @@ proc importPy(): void =
     let envs = getEnv("NIM_PYTHON_MODULES", "").split(":")
     let iSys = nimpy.pyImport("sys")
 
-    echo iSys.path
-
     discard iSys.path.extend(envs)
 
     let iBuiltins = nimpy.pyBuiltinsModule()

--- a/tablite/version.py
+++ b/tablite/version.py
@@ -1,3 +1,3 @@
-major, minor, patch = 2023, 10, 11
+major, minor, patch = 2023, 10, 12
 __version_info__ = (major, minor, patch)
 __version__ = ".".join(str(i) for i in __version_info__)


### PR DESCRIPTION
Fix an issue where layouts could potential get mismatched, never happened in column selector itself but managed to trigger it in functionality that uses `makePage` template directly.

Removed that unnecessary print statement.